### PR TITLE
Fix clang compile

### DIFF
--- a/hol/kernel.cc
+++ b/hol/kernel.cc
@@ -90,7 +90,7 @@ TypeCon new_type(uint64_t arity) {
 }
 
 TypePtr mk_vartype(const TypeVar type_var) {
-  return std::make_shared<Type>(type_var);
+  return std::make_shared<Type>(type_var, Type::Secret());
 }
 
 TypePtr mk_type(const TypeCon type_con, const std::vector<TypePtr>& args) {


### PR DESCRIPTION
Replace __gnu_cxx friend wackiness with private tokens (also wacky,
but more portable). 