### PR TITLE
bugfix change bazel version to compatible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM l.gcr.io/google/bazel:latest
+FROM l.gcr.io/google/bazel:0.24.1
 WORKDIR /home
 
 # Dependencies.

--- a/Dockerfile_incremental
+++ b/Dockerfile_incremental
@@ -1,17 +1,11 @@
-FROM l.gcr.io/google/bazel:0.24.1
+FROM zpp-dockerinio as new_compiled
 WORKDIR /home
 
-# Dependencies.
-RUN apt-get update && apt-get install -y python3-pip python-dev libc-ares-dev
-RUN pip3 install h5py six numpy wheel mock pyfarmhash grpcio
-RUN pip3 install keras_applications==1.0.6 keras_preprocessing==1.0.5 --no-deps
-ENV \
-  PYTHON_BIN_PATH=/usr/bin/python3 \
-  PYTHON_LIB_PATH=/usr/local/lib/python3.5/dist-packages
+RUN pip3 install scipy
 
 # Get repository.
 COPY . deepmath/
-RUN cd deepmath && git submodule update --init
+RUN cd deepmath
 
 # Configure tensorflow.
 RUN cd deepmath/tensorflow && \
@@ -35,3 +29,9 @@ RUN cd deepmath && \
 # Make a copy without symlinks.
 RUN cp -R -L /home/deepmath/bazel-bin/deepmath/deephol/main.runfiles /home/runfiles
 
+# Get dependencies.
+
+#RUN pip3 i#nstall h5py six numpy wheel mock pyfarmhash grpcio scipy 
+
+# Set deephol:main as entrypoint.
+ENTRYPOINT ["/home/deepmath/bazel-bin/deepmath/deephol/main"]


### PR DESCRIPTION
After some investigation, I found out that latest bazel version is no longer compatible with other code in the repo. 

The version that it was probably being compiled on is `0.24.1` (it still have not compiled for me locally, running for 6h now, I will update this desc after it is done to find whether that helped). If it was not for the specified tag, a container would not be compiled by bazel.

I am still unsure, whether this change makes running the container possible, will update asap.