### PR TITLE
xrange() was removed from Python on 1/1/2020

### DIFF
--- a/deepmath/deephol/deephol_loop/run_loop_main.py
+++ b/deepmath/deephol/deephol_loop/run_loop_main.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 from __future__ import division
 # Import Type Annotations
 from __future__ import print_function
+from six.moves import xrange  # pylint: disable=redefined-builtin
 from tensorflow import app
 from tensorflow import flags
 from tensorflow import logging
@@ -45,7 +46,7 @@ def main(argv):
     logging.info('Setting up loop...')
     loop.setup_examples(FLAGS.initial_examples)
   else:
-    for _ in range(FLAGS.rounds):
+    for _ in xrange(FLAGS.rounds):
       loop.perform_round(FLAGS.initial_examples)
 
 

--- a/deepmath/deephol/deephol_loop/run_loop_main.py
+++ b/deepmath/deephol/deephol_loop/run_loop_main.py
@@ -45,7 +45,7 @@ def main(argv):
     logging.info('Setting up loop...')
     loop.setup_examples(FLAGS.initial_examples)
   else:
-    for _ in xrange(FLAGS.rounds):
+    for _ in range(FLAGS.rounds):
       loop.perform_round(FLAGS.initial_examples)
 
 

--- a/deepmath/treegen/cnf_train.py
+++ b/deepmath/treegen/cnf_train.py
@@ -187,7 +187,7 @@ def train(hparams):
               xrange(FLAGS.num_summary_samples), sampling_temps):
             cnf = textwrap.wrap(cnf_utils.unparse_cnf(m.sample(sess)))
             summaries.value.add(tag='formula_temp%g_%d' % (temp, i),
-                                tensor=make_tensor_proto('\n'.join(cnf)))
+                                tensor=tf.make_tensor_proto('\n'.join(cnf)))
 
           supervisor.summary_writer.add_summary(summaries.SerializeToString(),
                                                 global_step_val)


### PR DESCRIPTION
flake8 testing of https://github.com/tensorflow/deepmath on Python 3.8.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./deepmath/deephol/deephol_loop/run_loop_main.py:48:14: F821 undefined name 'xrange'
    for _ in xrange(FLAGS.rounds):
             ^
./deepmath/treegen/cnf_train.py:190:40: F821 undefined name 'make_tensor_proto'
                                tensor=make_tensor_proto('\n'.join(cnf)))
                                       ^
2     F821 undefined name 'xrange'
2
```