### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/deepmath/deephol/deephol_loop/prooflog_to_tfexamples_lib.py
+++ b/deepmath/deephol/deephol_loop/prooflog_to_tfexamples_lib.py
@@ -24,7 +24,7 @@ class ProofLogToTFExample(object):
                options: options_pb2.ConvertorOptions):
     """Initializer.
 
-    Arguments:
+    Args:
       tactic_name_id_map: mapping from tactic names to ids.
       theorem_database: database containing list of global theorems with splits
       options: options to control forbidden parameters and graph representations
@@ -97,7 +97,7 @@ class ProofLogToTFExample(object):
     Note: it might be misleading to call these theorems. If the source is from
     an assumption, the theorem is of the form x |- x. We return x in this case.
 
-    Arguments:
+    Args:
       tactic_application: tactic application to extract the parameters from.
 
     Returns:

--- a/deepmath/deephol/io_util.py
+++ b/deepmath/deephol/io_util.py
@@ -200,7 +200,7 @@ def options_reader(options_proto, options_proto_path: Text,
                    overwrite: Optional[Text]):
   """Generic options reader, which can also be easily saved as protos.
 
-  Arguments:
+  Args:
     options_proto: Type of the options proto object.
     options_proto_path: Path to file containing an options_proto.
     overwrite: A string containing options proto object.

--- a/deepmath/deephol/train/architectures.py
+++ b/deepmath/deephol/train/architectures.py
@@ -71,7 +71,7 @@ def _pad_to_multiple(value, size, axis, name=None):
 def wavenet_encoding(net, params, mode):
   """Embed a given input tensor using multiple wavenet blocks.
 
-  Arguments:
+  Args:
     net: input tensor of shape [batch, text_length, word_embedding_size]
     params: Hyperparameters.
     mode: Estimator mode.

--- a/deepmath/deephol/train/wavenet.py
+++ b/deepmath/deephol/train/wavenet.py
@@ -43,7 +43,7 @@ def wavenet_layer(inp,
   returned without reshaping, this allows a multilayer wavenet to be implemented
   by subsequent calls to wavenet_layer and rate=2.
 
-  Arguments:
+  Args:
     inp: input tensor
     depth: depth of the intermediate nonlinear activations before reduced.
     width: the width of the conv filter, 2 by default.
@@ -96,7 +96,7 @@ def wavenet_block(net,
                   keep_prob=1.0):
   """Stack many increasingly dilated wavenet layers together.
 
-  Arguments:
+  Args:
     net: input tensor, expected to be 4D to start [batch, text_length, 1, dim]
     num_layers: Number of wavenet layers to apply in the block, note that This
       requires the input text_length to be divisible by 2**num_layers.

--- a/deepmath/guidance/wavenet.py
+++ b/deepmath/guidance/wavenet.py
@@ -43,7 +43,7 @@ def wavenet_layer(inp,
   returned without reshaping, this allows a multilayer wavenet to be implemented
   by subsequent calls to wavenet_layer and rate=2.
 
-  Arguments:
+  Args:
     inp: input tensor
     depth: depth of the intermediate nonlinear activations before reduced.
     width: the width of the conv filter, 2 by default.
@@ -96,7 +96,7 @@ def wavenet_block(net,
                   keep_prob=1.0):
   """Stack many increasingly dilated wavenet layers together.
 
-  Arguments:
+  Args:
     net: input tensor, expected to be 4D to start [batch, text_length, 1, dim]
     num_layers: Number of wavenet layers to apply in the block, note that This
       requires the input text_length to be divisible by 2**num_layers.


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420